### PR TITLE
Update __main__.py

### DIFF
--- a/s2aio/__main__.py
+++ b/s2aio/__main__.py
@@ -123,7 +123,7 @@ class S2AIO:
 
         self.windows_wait_time = int(config.get('scratch_info', 'windows_wait_time'))
 
-        self.scratch_project = self.base_path + '/ScratchFiles/ScratchProjects/' + scratch_block_language_dict[language]
+        self.scratch_project = '"' + self.base_path + '"' + '/ScratchFiles/ScratchProjects/' + scratch_block_language_dict[language]
 
         self.client = client
 


### PR DESCRIPTION
Solve issues related to whitespaces in the path of windows filepath.
Scratch.exe can be opened again